### PR TITLE
RAKP Message 1: implement layerexts.LayerDecodingLayer interface

### DIFF
--- a/pkg/ipmi/layer_types.go
+++ b/pkg/ipmi/layer_types.go
@@ -71,6 +71,9 @@ var (
 		1007,
 		gopacket.LayerTypeMetadata{
 			Name: "RAKP Message 1",
+			Decoder: layerexts.BuildDecoder(func() layerexts.LayerDecodingLayer {
+				return &RAKPMessage1{}
+			}),
 		},
 	)
 	LayerTypeRAKPMessage2 = gopacket.RegisterLayerType(

--- a/pkg/ipmi/rakp_message_1.go
+++ b/pkg/ipmi/rakp_message_1.go
@@ -75,6 +75,36 @@ func (r *RAKPMessage1) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Ser
 	return nil
 }
 
+func (*RAKPMessage1) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypePayload
+}
+
+func (r *RAKPMessage1) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 28 { // minimum in case of non-zero status code
+		df.SetTruncated()
+		return fmt.Errorf("RAKP Message 2 must be at least 28 bytes, got %v", len(data))
+	}
+	r.BaseLayer.Contents = data
+	r.Tag = uint8(data[0])
+	r.ManagedSystemSessionID = binary.LittleEndian.Uint32(data[4:8])
+	copy(r.RemoteConsoleRandom[:], data[8:24])
+	r.MaxPrivilegeLevel = PrivilegeLevel(data[24] & 0xF)
+	r.PrivilegeLevelLookup = (data[24] & (1 << 4)) == 0
+	lenUsername := data[27]
+	if lenUsername > 0 {
+		if lenUsername > 16 {
+			return fmt.Errorf("username should not be more than 16 characters long, got %v", lenUsername)
+		}
+		if len(data) < int(28+lenUsername) {
+			df.SetTruncated()
+			return fmt.Errorf("RAKP Message 2 not long enough to contain username. Expected %v, got %v", 28+lenUsername, len(data))
+		}
+		r.Username = string(data[28 : 28+lenUsername])
+	}
+
+	return nil
+}
+
 type RAKPMessage1Payload struct {
 	Req RAKPMessage1
 	Rsp RAKPMessage2

--- a/pkg/ipmi/rakp_message_1_test.go
+++ b/pkg/ipmi/rakp_message_1_test.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/gopacket"
 )
 
 func TestRAKPMessage1SerializeTo(t *testing.T) {
 	table := []struct {
+		name  string
 		layer *RAKPMessage1
 		wire  []byte
 	}{
 		{
-			// empty username, role-based lookup
+			"empty username, role-based lookup",
 			&RAKPMessage1{
 				Tag:                    0x22,
 				ManagedSystemSessionID: 0x1020304,
@@ -29,7 +31,7 @@ func TestRAKPMessage1SerializeTo(t *testing.T) {
 				0x02, 0x00, 0x00, 0x00},
 		},
 		{
-			// non-empty username, username only lookup
+			"non-empty username, username only lookup",
 			&RAKPMessage1{
 				Tag:                    0x1,
 				ManagedSystemSessionID: 0x4030201,
@@ -45,7 +47,7 @@ func TestRAKPMessage1SerializeTo(t *testing.T) {
 				0x14, 0x00, 0x00, 0x06, 'g', 'e', 'o', 'r', 'g', 'e'},
 		},
 		{
-			// non-empty username, role-based lookup
+			"non-empty username, role-based lookup",
 			&RAKPMessage1{
 				Tag:                    0xff,
 				ManagedSystemSessionID: 0x1040203,
@@ -64,40 +66,27 @@ func TestRAKPMessage1SerializeTo(t *testing.T) {
 	}
 	opts := gopacket.SerializeOptions{}
 	for _, test := range table {
-		sb := gopacket.NewSerializeBuffer()
-		if err := test.layer.SerializeTo(sb, opts); err != nil {
-			t.Errorf("serialize %v = error %v, want %v", test.layer, err,
-				test.wire)
-			continue
-		}
-		got := sb.Bytes()
-		if !bytes.Equal(got, test.wire) {
-			t.Errorf("serialize %v = %v, want %v", test.layer, got, test.wire)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			sb := gopacket.NewSerializeBuffer()
+			if err := test.layer.SerializeTo(sb, opts); err != nil {
+				t.Errorf("serialize %v = error %v, want %v", test.layer, err,
+					test.wire)
+				return
+			}
+			got := sb.Bytes()
+			if !bytes.Equal(got, test.wire) {
+				t.Errorf("serialize %v = %v, want %v", test.layer, got, test.wire)
+			}
 
-		var decoded RAKPMessage1
-		if err := decoded.DecodeFromBytes(got, nil); err != nil {
-			t.Errorf("decode %v = error %v", test.layer, err)
-			continue
-		}
-		r := test.layer
-		if r.Tag != decoded.Tag {
-			t.Errorf("decode %v Tag = got %v, want %v", test.layer, decoded.Tag, r.Tag)
-		}
-		if r.ManagedSystemSessionID != decoded.ManagedSystemSessionID {
-			t.Errorf("decode %v ManagedSystemSessionID = got %v, want %v", test.layer, decoded.ManagedSystemSessionID, r.ManagedSystemSessionID)
-		}
-		if r.RemoteConsoleRandom != decoded.RemoteConsoleRandom {
-			t.Errorf("decode %v RemoteConsoleRandom = got %v, want %v", test.layer, decoded.RemoteConsoleRandom, r.RemoteConsoleRandom)
-		}
-		if r.MaxPrivilegeLevel != decoded.MaxPrivilegeLevel {
-			t.Errorf("decode %v MaxPrivilegeLevel = got %v, want %v", test.layer, decoded.MaxPrivilegeLevel, r.MaxPrivilegeLevel)
-		}
-		if r.PrivilegeLevelLookup != decoded.PrivilegeLevelLookup {
-			t.Errorf("decode %v PrivilegeLevelLookup = got %v, want %v", test.layer, decoded.PrivilegeLevelLookup, r.PrivilegeLevelLookup)
-		}
-		if r.Username != decoded.Username {
-			t.Errorf("decode %v Username = got %v, want %v", test.layer, decoded.Username, r.Username)
-		}
+			layer := &RAKPMessage1{}
+			if err := layer.DecodeFromBytes(got, gopacket.NilDecodeFeedback); err != nil {
+				t.Errorf("decode %v = error %v", test.layer, err)
+				return
+			}
+			test.layer.BaseLayer.Contents = got
+			if diff := cmp.Diff(test.layer, layer); diff != "" {
+				t.Errorf("decode %v = %v, want %v: %v", test.wire, layer, test.layer, diff)
+			}
+		})
 	}
 }

--- a/pkg/ipmi/rakp_message_1_test.go
+++ b/pkg/ipmi/rakp_message_1_test.go
@@ -74,5 +74,30 @@ func TestRAKPMessage1SerializeTo(t *testing.T) {
 		if !bytes.Equal(got, test.wire) {
 			t.Errorf("serialize %v = %v, want %v", test.layer, got, test.wire)
 		}
+
+		var decoded RAKPMessage1
+		if err := decoded.DecodeFromBytes(got, nil); err != nil {
+			t.Errorf("decode %v = error %v", test.layer, err)
+			continue
+		}
+		r := test.layer
+		if r.Tag != decoded.Tag {
+			t.Errorf("decode %v Tag = got %v, want %v", test.layer, decoded.Tag, r.Tag)
+		}
+		if r.ManagedSystemSessionID != decoded.ManagedSystemSessionID {
+			t.Errorf("decode %v ManagedSystemSessionID = got %v, want %v", test.layer, decoded.ManagedSystemSessionID, r.ManagedSystemSessionID)
+		}
+		if r.RemoteConsoleRandom != decoded.RemoteConsoleRandom {
+			t.Errorf("decode %v RemoteConsoleRandom = got %v, want %v", test.layer, decoded.RemoteConsoleRandom, r.RemoteConsoleRandom)
+		}
+		if r.MaxPrivilegeLevel != decoded.MaxPrivilegeLevel {
+			t.Errorf("decode %v MaxPrivilegeLevel = got %v, want %v", test.layer, decoded.MaxPrivilegeLevel, r.MaxPrivilegeLevel)
+		}
+		if r.PrivilegeLevelLookup != decoded.PrivilegeLevelLookup {
+			t.Errorf("decode %v PrivilegeLevelLookup = got %v, want %v", test.layer, decoded.PrivilegeLevelLookup, r.PrivilegeLevelLookup)
+		}
+		if r.Username != decoded.Username {
+			t.Errorf("decode %v Username = got %v, want %v", test.layer, decoded.Username, r.Username)
+		}
 	}
 }


### PR DESCRIPTION
This PR adds the ability to decode `RAKP Message 1`.

See #44 for some background, why we need this.

---

I set the `NextLayerType` to `gopacket.LayerTypePayload` (like Message 2 and 4), but I have no idea if this is correct :see_no_evil: 