### PR TITLE
ipmi: implement Set Session Privilege Level command

### DIFF
--- a/pkg/ipmi/layer_types.go
+++ b/pkg/ipmi/layer_types.go
@@ -227,7 +227,6 @@ var (
 			}),
 		},
 	)
-
 	LayerTypeSetSessionPrivilegeLevelReq = gopacket.RegisterLayerType(
 		1027,
 		gopacket.LayerTypeMetadata{

--- a/pkg/ipmi/layer_types.go
+++ b/pkg/ipmi/layer_types.go
@@ -227,4 +227,20 @@ var (
 			}),
 		},
 	)
+
+	LayerTypeSetSessionPrivilegeLevelReq = gopacket.RegisterLayerType(
+		1027,
+		gopacket.LayerTypeMetadata{
+			Name: "Set Session Privilege Level Request",
+		},
+	)
+	LayerTypeSetSessionPrivilegeLevelRsp = gopacket.RegisterLayerType(
+		1028,
+		gopacket.LayerTypeMetadata{
+			Name: "Set Session Privilege Level Response",
+			Decoder: layerexts.BuildDecoder(func() layerexts.LayerDecodingLayer {
+				return &SetSessionPrivilegeLevelRsp{}
+			}),
+		},
+	)
 )

--- a/pkg/ipmi/operation.go
+++ b/pkg/ipmi/operation.go
@@ -70,6 +70,10 @@ var (
 		Function: NetworkFunctionAppReq,
 		Command:  0x3b,
 	}
+	OperationSetSessionPrivilegeLevelRsp = Operation{
+		Function: NetworkFunctionAppRsp,
+		Command:  0x3b,
+	}
 	OperationCloseSessionReq = Operation{
 		Function: NetworkFunctionAppReq,
 		Command:  0x3c,
@@ -121,6 +125,7 @@ var (
 		OperationGetChassisStatusRsp:                     LayerTypeGetChassisStatusRsp,
 		OperationGetSystemGUIDRsp:                        LayerTypeGetSystemGUIDRsp,
 		OperationGetChannelAuthenticationCapabilitiesRsp: LayerTypeGetChannelAuthenticationCapabilitiesRsp,
+		OperationSetSessionPrivilegeLevelRsp:             LayerTypeSetSessionPrivilegeLevelRsp,
 		OperationGetSDRRepositoryInfoRsp:                 LayerTypeGetSDRRepositoryInfoRsp,
 		OperationGetSDRRsp:                               LayerTypeGetSDRRsp,
 		OperationGetSensorReadingRsp:                     LayerTypeGetSensorReadingRsp,

--- a/pkg/ipmi/operation.go
+++ b/pkg/ipmi/operation.go
@@ -66,6 +66,10 @@ var (
 		Function: NetworkFunctionAppRsp,
 		Command:  0x38,
 	}
+	OperationSetSessionPrivilegeLevelReq = Operation{
+		Function: NetworkFunctionAppReq,
+		Command:  0x3b,
+	}
 	OperationCloseSessionReq = Operation{
 		Function: NetworkFunctionAppReq,
 		Command:  0x3c,

--- a/pkg/ipmi/set_session_privilege_level.go
+++ b/pkg/ipmi/set_session_privilege_level.go
@@ -58,7 +58,7 @@ func (*SetSessionPrivilegeLevelRsp) NextLayerType() gopacket.LayerType {
 }
 
 func (r *SetSessionPrivilegeLevelRsp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	if len(data) != 1 { // minimum in case of non-zero status code
+	if len(data) != 1 { // in case of non-zero status code
 		df.SetTruncated()
 		return fmt.Errorf("Set Session Privilege Level Response must be 1 byte, got %v", len(data))
 	}

--- a/pkg/ipmi/set_session_privilege_level.go
+++ b/pkg/ipmi/set_session_privilege_level.go
@@ -1,0 +1,84 @@
+package ipmi
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// SetSessionPrivilegeLevelReq implements the Set Session Privilege Level command, specified in section
+// 18.16 of v1.5 and 22.18 of v2.0.
+type SetSessionPrivilegeLevelReq struct {
+	layers.BaseLayer
+
+	// PrivilegeLevel indicates the privilege level to switch to.
+	// Set to 0 to retrieve the present privilege level.
+	PrivilegeLevel PrivilegeLevel
+}
+
+func (*SetSessionPrivilegeLevelReq) LayerType() gopacket.LayerType {
+	return LayerTypeSetSessionPrivilegeLevelReq
+}
+
+func (c *SetSessionPrivilegeLevelReq) SerializeTo(b gopacket.SerializeBuffer, _ gopacket.SerializeOptions) error {
+	bytes, err := b.PrependBytes(1)
+	if err != nil {
+		return err
+	}
+	bytes[0] = uint8(c.PrivilegeLevel) & 0xF
+	return nil
+}
+
+type SetSessionPrivilegeLevelRsp struct {
+	layers.BaseLayer
+
+	// PrivilegeLevel indicates the new (or present) privilege level of the user in the
+	// active session.
+	PrivilegeLevel PrivilegeLevel
+}
+
+func (*SetSessionPrivilegeLevelRsp) LayerType() gopacket.LayerType {
+	return LayerTypeSetSessionPrivilegeLevelRsp
+}
+
+func (r *SetSessionPrivilegeLevelRsp) CanDecode() gopacket.LayerClass {
+	return r.LayerType()
+}
+
+func (*SetSessionPrivilegeLevelRsp) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypePayload
+}
+
+func (r *SetSessionPrivilegeLevelRsp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 1 { // minimum in case of non-zero status code
+		df.SetTruncated()
+		return fmt.Errorf("Set Session Privilege Level Response must be at least 1 bytes, got %v", len(data))
+	}
+
+	r.PrivilegeLevel = PrivilegeLevel(data[0] & 0xF)
+	return nil
+}
+
+type SetSessionPrivilegeLevelCmd struct {
+	Req SetSessionPrivilegeLevelReq
+	Rsp SetSessionPrivilegeLevelRsp
+}
+
+// Name returns "Set Session Privilege Level".
+func (*SetSessionPrivilegeLevelCmd) Name() string {
+	return "Set Session Privilege Level"
+}
+
+// Operation returns OperationSetSessionPrivilegeLevelReq.
+func (*SetSessionPrivilegeLevelCmd) Operation() *Operation {
+	return &OperationSetSessionPrivilegeLevelReq
+}
+
+func (c *SetSessionPrivilegeLevelCmd) Request() gopacket.SerializableLayer {
+	return &c.Req
+}
+
+func (c *SetSessionPrivilegeLevelCmd) Response() gopacket.DecodingLayer {
+	return &c.Rsp
+}

--- a/session_commands.go
+++ b/session_commands.go
@@ -43,6 +43,10 @@ type SessionCommands interface {
 	// it requires the SDR.
 	GetSensorReading(context.Context, uint8) (*ipmi.GetSensorReadingRsp, error)
 
+	// GetSessionPrivilegeLevel retrieves the current session privilege level. This is
+	// specified in 18.16 and 22.18 of IPMI v1.5 and 2.0 respectively.
+	GetSessionPrivilegeLevel(context.Context) (ipmi.PrivilegeLevel, error)
+
 	// SetSessionPrivilegeLevel sends a Set Session Privilege Level command to the BMC. This is
 	// specified in 18.16 and 22.18 of IPMI v1.5 and 2.0 respectively.
 	// PrivilegeLevelHighest and PrivilegeLevelCallback are invalid values.

--- a/session_commands.go
+++ b/session_commands.go
@@ -45,7 +45,7 @@ type SessionCommands interface {
 
 	// SetSessionPrivilegeLevel sends a Set Session Privilege Level command to the BMC. This is
 	// specified in 18.16 and 22.18 of IPMI v1.5 and 2.0 respectively.
-	// If the PrivilegeLevel argument is 0, it will return the current session privilege level.
+	// PrivilegeLevelHighest and PrivilegeLevelCallback are invalid values.
 	SetSessionPrivilegeLevel(context.Context, ipmi.PrivilegeLevel) (ipmi.PrivilegeLevel, error)
 
 	// closeSession sends a Close Session command to the BMC. It is unexported

--- a/session_commands.go
+++ b/session_commands.go
@@ -43,6 +43,11 @@ type SessionCommands interface {
 	// it requires the SDR.
 	GetSensorReading(context.Context, uint8) (*ipmi.GetSensorReadingRsp, error)
 
+	// SetSessionPrivilegeLevel sends a Set Session Privilege Level command to the BMC. This is
+	// specified in 18.16 and 22.18 of IPMI v1.5 and 2.0 respectively.
+	// If the PrivilegeLevel argument is 0, it will return the current session privilege level.
+	SetSessionPrivilegeLevel(context.Context, ipmi.PrivilegeLevel) (*ipmi.SetSessionPrivilegeLevelRsp, error)
+
 	// closeSession sends a Close Session command to the BMC. It is unexported
 	// as calling it randomly would leave the session in an invalid state. Call
 	// Close() on the session itself to invoke this.

--- a/session_commands.go
+++ b/session_commands.go
@@ -46,7 +46,7 @@ type SessionCommands interface {
 	// SetSessionPrivilegeLevel sends a Set Session Privilege Level command to the BMC. This is
 	// specified in 18.16 and 22.18 of IPMI v1.5 and 2.0 respectively.
 	// If the PrivilegeLevel argument is 0, it will return the current session privilege level.
-	SetSessionPrivilegeLevel(context.Context, ipmi.PrivilegeLevel) (*ipmi.SetSessionPrivilegeLevelRsp, error)
+	SetSessionPrivilegeLevel(context.Context, ipmi.PrivilegeLevel) (ipmi.PrivilegeLevel, error)
 
 	// closeSession sends a Close Session command to the BMC. It is unexported
 	// as calling it randomly would leave the session in an invalid state. Call

--- a/v2session.go
+++ b/v2session.go
@@ -283,16 +283,16 @@ func (s *V2Session) GetSensorReading(ctx context.Context, sensor uint8) (*ipmi.G
 	return &cmd.Rsp, nil
 }
 
-func (s *V2Session) SetSessionPrivilegeLevel(ctx context.Context, level ipmi.PrivilegeLevel) (*ipmi.SetSessionPrivilegeLevelRsp, error) {
+func (s *V2Session) SetSessionPrivilegeLevel(ctx context.Context, level ipmi.PrivilegeLevel) (ipmi.PrivilegeLevel, error) {
 	cmd := &ipmi.SetSessionPrivilegeLevelCmd{
 		Req: ipmi.SetSessionPrivilegeLevelReq{
 			PrivilegeLevel: level,
 		},
 	}
 	if err := ValidateResponse(s.SendCommand(ctx, cmd)); err != nil {
-		return nil, err
+		return 0, err
 	}
-	return &cmd.Rsp, nil
+	return cmd.Rsp.PrivilegeLevel, nil
 }
 
 func (s *V2Session) closeSession(ctx context.Context) error {

--- a/v2session.go
+++ b/v2session.go
@@ -283,6 +283,18 @@ func (s *V2Session) GetSensorReading(ctx context.Context, sensor uint8) (*ipmi.G
 	return &cmd.Rsp, nil
 }
 
+func (s *V2Session) SetSessionPrivilegeLevel(ctx context.Context, level ipmi.PrivilegeLevel) (*ipmi.SetSessionPrivilegeLevelRsp, error) {
+	cmd := &ipmi.SetSessionPrivilegeLevelCmd{
+		Req: ipmi.SetSessionPrivilegeLevelReq{
+			PrivilegeLevel: level,
+		},
+	}
+	if err := ValidateResponse(s.SendCommand(ctx, cmd)); err != nil {
+		return nil, err
+	}
+	return &cmd.Rsp, nil
+}
+
 func (s *V2Session) closeSession(ctx context.Context) error {
 	// we decrement regardless of whether this command succeeds, as to not do so
 	// would be overly pessimistic - if it fails, there's nothing we can do;

--- a/v2session.go
+++ b/v2session.go
@@ -283,6 +283,18 @@ func (s *V2Session) GetSensorReading(ctx context.Context, sensor uint8) (*ipmi.G
 	return &cmd.Rsp, nil
 }
 
+func (s *V2Session) GetSessionPrivilegeLevel(ctx context.Context) (ipmi.PrivilegeLevel, error) {
+	cmd := &ipmi.SetSessionPrivilegeLevelCmd{
+		Req: ipmi.SetSessionPrivilegeLevelReq{
+			// PrivilegeLevel omitted to retrieve current level
+		},
+	}
+	if err := ValidateResponse(s.SendCommand(ctx, cmd)); err != nil {
+		return 0, err
+	}
+	return cmd.Rsp.PrivilegeLevel, nil
+}
+
 func (s *V2Session) SetSessionPrivilegeLevel(ctx context.Context, level ipmi.PrivilegeLevel) (ipmi.PrivilegeLevel, error) {
 	cmd := &ipmi.SetSessionPrivilegeLevelCmd{
 		Req: ipmi.SetSessionPrivilegeLevelReq{


### PR DESCRIPTION
Fixes #44.

By doing some copy/paste of `close_session.go` and other files, I was able to make a `SetSessionPrivilegeLevelCmd`.

Used like this, it fixes my issue:
```go

	sess, err := machine.NewSession(ctx, &bmc.SessionOpts{
		Username:          c.Username,
		Password:          []byte(c.Password),
		MaxPrivilegeLevel: ipmi.PrivilegeLevelOperator,
	})
	if err != nil {
		return err
	}
	defer sess.Close(ctx)

	privup := &ipmi.SetSessionPrivilegeLevelCmd{
		Req: ipmi.SetSessionPrivilegeLevelReq{
			PrivilegeLevel: ipmi.PrivilegeLevelOperator,
		},
	}
	code, err := sess.SendCommand(ctx, privup)
```

Maybe it could be somehow automated:
- preemptively if we know that the present level is too low for the next command, but the max level is high enough
- or reactively, when receiving a `0xd4(Insufficient Privileges)`, upgrade the level (to the max) and retry

But it is probably better to keep this automation for another PR.