### PR TITLE
Implement Get Channel Cipher Suites command

### DIFF
--- a/pkg/ipmi/get_channel_cipher_suites.go
+++ b/pkg/ipmi/get_channel_cipher_suites.go
@@ -1,0 +1,212 @@
+package ipmi
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// Get Channel Cipher Suites comamand is specified in 22.15 of IPMI v2.0, the
+// command is used to look up what authentication, integrity and confidentiality
+// algorithms are supported, The algorithms are used in combination as
+// 'Cipher Suites'. This command only applies to implementations that support
+// IPMI v2.0/RMCP+ sessions.
+
+// CipherSuiteData represents Cipher Suites type and algorighm tag and its ID.
+type CipherSuiteData uint8
+
+// OEMIANAType represents IANA for the OEM or body that defined the Cipher Suite
+// which includes 3 little endian bytes.
+type OEMIANAType uint32
+
+const (
+	// StandardCipherSuite or OEMCipherSuite is a start of record byte, which is
+	// specified in Table 22-19, IPMI2.0.
+	StandardCipherSuite CipherSuiteData = 0xc0
+	OEMCipherSuite      CipherSuiteData = 0xc1
+
+	// ListAlgorithmByCipherSuite is a bit to list algorighms by Cipher Suite
+	// instead of list all supported algorithms (Table 22-18, IPMI2.0).
+	ListAlgorithmByCipherSuite CipherSuiteData = 0x80
+
+	// AuthenticationAlgorithmTag a tag that indicate last 5 bits is
+	// authentication algorighm number.
+	AuthenticationAlgorithmTag CipherSuiteData = 0x00
+	// IntegrityAlgorithmTag is a tag that indicate last 5 bits is integrity
+	// algorighm number.
+	IntegrityAlgorithmTag CipherSuiteData = 0x01
+	// ConfidentialityAlgorithmTag is a tag that indicate last 5 bits is
+	// confidentiality algorithm number.
+	ConfidentialityAlgorithmTag CipherSuiteData = 0x02
+
+	// CipherSuiteID_* is the IDs for Cipher Suite, specified in Table 22-20 of
+	// IPMI2.0, 17 and 3 are most widely supported so far, they will be used for
+	// detecting the best Cipher Suite.
+	CipherSuiteID_3  CipherSuiteData = 3
+	CipherSuiteID_17 CipherSuiteData = 17
+)
+
+// GetChannelCipherSuitesReq defines a Get Channel Cipher Suites request. Its format
+// is specified in Table 22-18 of IPMV v2.0.
+type GetChannelCipherSuitesReq struct {
+	layers.BaseLayer
+
+	// Channel number of current request, bits[7:4] are reserved, and bits[3:0]
+	// are for channel number, and 0h-Bh, Fh are channel numbers, Eh retrieve
+	// information for channel this request was issued on.
+	Channel Channel
+
+	// The Payload Type number is used to look up the Security Algorithm support
+	// when establishing a separate session for a given payload type. Typically
+	// the number is 00h (IPMI).
+	PayloadType PayloadType
+
+	// List index (00h-3Fh). 0h selects the first set of 16, 1h selects the next
+	// set of 16, and so on.
+	// When use 00h to get first set of algorithm numbers. The BMC returns 16
+	// bytes at a time per index, starting from index 00h, until the list
+	// data is exhausted, at which point it will 0 bytes or <16 bytes of list
+	// data.
+	ListIndex CipherSuiteData
+}
+
+func (*GetChannelCipherSuitesReq) LayerType() gopacket.LayerType {
+	return LayerTypeGetChannelCipherSuitesReq
+}
+
+func (g *GetChannelCipherSuitesReq) SerializeTo(b gopacket.SerializeBuffer, _ gopacket.SerializeOptions) error {
+	bytes, err := b.PrependBytes(3)
+	if err != nil {
+		return err
+	}
+	bytes[0] = uint8(g.Channel)
+	bytes[1] = uint8(g.PayloadType)
+
+	// Always list algorighms by Cipher Suite instead of list all supported
+	// algorithms.
+	bytes[2] = uint8(g.ListIndex | ListAlgorithmByCipherSuite)
+	return nil
+}
+
+// GetChannelCipherSuitesRsp represents the response to a Get Channel Cipher Suites
+// request.
+type GetChannelCipherSuitesRsp struct {
+	layers.BaseLayer
+
+	// Channel number that the Authentication Algorithms are being returned
+	// for. If the channel number in the request was set to Eh, this will return
+	// the channel number for the channel that the request was received on.
+	Channel Channel
+
+	// ID is the Cipher Suite ID, a numeric way of identifying the Cipher Suite
+	// on the platform. It’s used in commands and configuration parameters that
+	// enable and disable Cipher Suites (Table 22-20, IPMI v2.0).
+	ID CipherSuiteData
+
+	// Type indicate the start of record, Standard or OEM Cipher Suite.
+	Type CipherSuiteData
+
+	// OEMIANA is Least significant byte first. 3-byte IANA for the OEM or body
+	// that defined the Cipher Suite.
+	OEMIANA OEMIANAType
+
+	// ListDataExhausted indicate the list data is exhausted.
+	ListDataExhausted bool
+
+	// AuthenticationAlgorithms is a list to align with Session options, a
+	// Cipher Suite is only allowed to utilize one authentication algorithm.
+	AuthenticationAlgorithms []AuthenticationAlgorithm
+
+	// IntegrityAlgorithms defines all supported interity algorithms.
+	IntegrityAlgorithms []IntegrityAlgorithm
+
+	// ConfidentialityAlgorithms defines all supported confidentiality algorithms.
+	ConfidentialityAlgorithms []ConfidentialityAlgorithm
+}
+
+func (*GetChannelCipherSuitesRsp) LayerType() gopacket.LayerType {
+	return LayerTypeGetChannelCipherSuitesRsp
+}
+
+func (g *GetChannelCipherSuitesRsp) CanDecode() gopacket.LayerClass {
+	return g.LayerType()
+}
+
+func (*GetChannelCipherSuitesRsp) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypePayload
+}
+
+func (g *GetChannelCipherSuitesRsp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	length := len(data)
+	if length < 6 {
+		df.SetTruncated()
+		return fmt.Errorf("response must be at least 6 bytes for the cipher suite, got %v",
+			length)
+	}
+
+	// Check the Cipher Suite type first, they have different data bytes.
+	g.Type = CipherSuiteData(data[1])
+	if g.Type != StandardCipherSuite && g.Type != OEMCipherSuite {
+		return fmt.Errorf("unexpected cipher suite type, got %v", g.Type)
+	}
+
+	g.Channel = Channel(data[0])
+	g.ID = CipherSuiteData(data[2])
+	offset := 3
+
+	// OEM Chipher Suite need 3 more bytes for OEM IANA.
+	if g.Type == OEMCipherSuite {
+		g.OEMIANA = OEMIANAType(uint32(data[3]) + uint32(data[4])<<8 + uint32(data[5])<<16)
+		offset += 3
+	}
+
+	// The size of these algorithms is variable, detect them with its tag.
+	for i := offset; i < length; i++ {
+		switch CipherSuiteData(data[i] >> 6) {
+		case AuthenticationAlgorithmTag:
+			g.AuthenticationAlgorithms = append(g.AuthenticationAlgorithms, AuthenticationAlgorithm(data[i]&0x1f))
+		case IntegrityAlgorithmTag:
+			g.IntegrityAlgorithms = append(g.IntegrityAlgorithms, IntegrityAlgorithm(data[i]&0x1f))
+		case ConfidentialityAlgorithmTag:
+			g.ConfidentialityAlgorithms = append(g.ConfidentialityAlgorithms, ConfidentialityAlgorithm(data[i]&0x1f))
+		}
+	}
+
+	// The number 17 is 16 data bytes plus a index.
+	// The BMC returns sixteen (16) bytes at a time per index, starting from index
+	// 00h, until the list data is exhausted, at which point it will 0 bytes or <16
+	// bytes of list data.
+	if length == 17 {
+		g.ListDataExhausted = false
+	} else {
+		g.ListDataExhausted = true
+	}
+
+	g.BaseLayer.Contents = data[:length]
+	g.BaseLayer.Payload = data[length:]
+	return nil
+}
+
+type GetChannelCipherCmd struct {
+	Req GetChannelCipherSuitesReq
+	Rsp GetChannelCipherSuitesRsp
+}
+
+// Name returns "Get Channel Cipher Suite".
+func (*GetChannelCipherCmd) Name() string {
+	return "Get Channel Cipher Suite"
+}
+
+// Operation returns &OperationGetChannelCipherSuitesReq.
+func (*GetChannelCipherCmd) Operation() *Operation {
+	return &OperationGetChannelCipherSuitesReq
+}
+
+func (c *GetChannelCipherCmd) Request() gopacket.SerializableLayer {
+	return &c.Req
+}
+
+func (c *GetChannelCipherCmd) Response() gopacket.DecodingLayer {
+	return &c.Rsp
+}

--- a/pkg/ipmi/get_channel_cipher_suites_test.go
+++ b/pkg/ipmi/get_channel_cipher_suites_test.go
@@ -1,0 +1,137 @@
+package ipmi
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+func TestGetChannelCipherSuitesReqSerializeTo(t *testing.T) {
+	table := []struct {
+		layer *GetChannelCipherSuitesReq
+		want  []byte
+	}{
+		{
+			&GetChannelCipherSuitesReq{
+				Channel:     12,
+				PayloadType: 34,
+				ListIndex:   56,
+			},
+			[]byte{
+				0x0c,
+				0x22,
+				0x38 | 0x80,
+			},
+		},
+		{
+			&GetChannelCipherSuitesReq{
+				Channel:     56,
+				PayloadType: 12,
+				ListIndex:   34,
+			},
+			[]byte{
+				0x38,
+				0x0c,
+				0x22 | 0x80,
+			},
+		},
+	}
+	for _, test := range table {
+		sb := gopacket.NewSerializeBuffer()
+		err := test.layer.SerializeTo(sb, gopacket.SerializeOptions{})
+		got := sb.Bytes()
+
+		switch {
+		case err != nil && test.want != nil:
+			t.Errorf("serialize %v failed with %v, wanted %v", test.layer, err, test.want)
+		case err == nil && !bytes.Equal(got, test.want):
+			t.Errorf("serialize %v = %v, want %v", test.layer, got, test.want)
+		}
+	}
+}
+
+func TestGetChannelCipherSuitesRspDecodeFromBytes(t *testing.T) {
+	tests := []struct {
+		in   []byte
+		want *GetChannelCipherSuitesRsp
+	}{
+		// too short
+		{
+			make([]byte, 1),
+			nil,
+		},
+		{
+			[]byte{
+				0x03, 0xc0, 0x11, 0x02, 0x42, 0x81,
+			},
+			&GetChannelCipherSuitesRsp{
+				BaseLayer: layers.BaseLayer{
+					Contents: []byte{0x03, 0xc0, 0x11, 0x02, 0x42, 0x81},
+					Payload:  []byte{},
+				},
+				Channel:           3,
+				ID:                17,
+				Type:              0xc0,
+				OEMIANA:           0,
+				ListDataExhausted: true,
+				AuthenticationAlgorithms: []AuthenticationAlgorithm{
+					AuthenticationAlgorithmHMACMD5,
+				},
+				IntegrityAlgorithms: []IntegrityAlgorithm{
+					IntegrityAlgorithmHMACMD5128,
+				},
+				ConfidentialityAlgorithms: []ConfidentialityAlgorithm{
+					ConfidentialityAlgorithmAESCBC128,
+				},
+			},
+		},
+		{
+			[]byte{
+				0x01, 0xc1, 0x03, 0x01, 0x02, 0x03,
+				0x01, 0x41, 0x82, 0x42, 0x81,
+			},
+			&GetChannelCipherSuitesRsp{
+				BaseLayer: layers.BaseLayer{
+					Contents: []byte{
+						0x01, 0xc1, 0x03, 0x01, 0x02, 0x03,
+						0x01, 0x41, 0x82, 0x42, 0x81,
+					},
+					Payload: []byte{},
+				},
+				Channel:           1,
+				ID:                3,
+				Type:              0xc1,
+				OEMIANA:           0x030201,
+				ListDataExhausted: true,
+				AuthenticationAlgorithms: []AuthenticationAlgorithm{
+					AuthenticationAlgorithmHMACSHA1,
+				},
+				IntegrityAlgorithms: []IntegrityAlgorithm{
+					IntegrityAlgorithmHMACSHA196,
+					IntegrityAlgorithmHMACMD5128,
+				},
+				ConfidentialityAlgorithms: []ConfidentialityAlgorithm{
+					ConfidentialityAlgorithmXRC4128,
+					ConfidentialityAlgorithmAESCBC128,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		rsp := &GetChannelCipherSuitesRsp{}
+		err := rsp.DecodeFromBytes(test.in, gopacket.NilDecodeFeedback)
+		switch {
+		case err == nil && test.want == nil:
+			t.Errorf("expected error decoding %v, got none", test.in)
+		case err == nil && test.want != nil:
+			if diff := cmp.Diff(test.want, rsp); diff != "" {
+				t.Errorf("decode %v = %v, want %v: %v", test.in, rsp, test.want, diff)
+			}
+		case err != nil && test.want != nil:
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}

--- a/pkg/ipmi/layer_types.go
+++ b/pkg/ipmi/layer_types.go
@@ -242,4 +242,19 @@ var (
 			}),
 		},
 	)
+	LayerTypeGetChannelCipherSuitesReq = gopacket.RegisterLayerType(
+		1029,
+		gopacket.LayerTypeMetadata{
+			Name: "Get Channel Cipher Suites Request",
+		},
+	)
+	LayerTypeGetChannelCipherSuitesRsp = gopacket.RegisterLayerType(
+		1030,
+		gopacket.LayerTypeMetadata{
+			Name: "Get Channel Cipher Suites Response",
+			Decoder: layerexts.BuildDecoder(func() layerexts.LayerDecodingLayer {
+				return &GetChannelCipherSuitesRsp{}
+			}),
+		},
+	)
 )

--- a/pkg/ipmi/operation.go
+++ b/pkg/ipmi/operation.go
@@ -110,6 +110,14 @@ var (
 		Function: NetworkFunctionAppRsp,
 		Command:  0x3d,
 	}
+	OperationGetChannelCipherSuitesReq = Operation{
+		Function: NetworkFunctionAppReq,
+		Command:  0x54,
+	}
+	OperationGetChannelCipherSuitesRsp = Operation{
+		Function: NetworkFunctionAppRsp,
+		Command:  0x54,
+	}
 
 	// operationLayerTypes is how a Message finds out how to decode its
 	// payload. It tells us which layer comes next given a network function and
@@ -130,6 +138,7 @@ var (
 		OperationGetSDRRsp:                               LayerTypeGetSDRRsp,
 		OperationGetSensorReadingRsp:                     LayerTypeGetSensorReadingRsp,
 		OperationGetSessionInfoRsp:                       LayerTypeGetSessionInfoRsp,
+		OperationGetChannelCipherSuitesRsp:               LayerTypeGetChannelCipherSuitesRsp,
 	}
 )
 

--- a/sessionless_commands.go
+++ b/sessionless_commands.go
@@ -24,4 +24,9 @@ type SessionlessCommands interface {
 	// as a keepalive, however could be useful to scan an estate for
 	// compatibility.
 	GetChannelAuthenticationCapabilities(context.Context, *ipmi.GetChannelAuthenticationCapabilitiesReq) (*ipmi.GetChannelAuthenticationCapabilitiesRsp, error)
+
+	// GetBestCipherSuite issues the Get Channel Cipher Suites comamand to BMC,
+	// which is specified in 22.15 of IPMI v2.0. Then it would select a best
+	// one from a given list, and fall back to Cipher Suite 3 when it failed.
+	GetBestCipherSuite(context.Context) (*ipmi.GetChannelCipherSuitesRsp, error)
 }

--- a/v2session.go
+++ b/v2session.go
@@ -307,6 +307,10 @@ func (s *V2Session) SetSessionPrivilegeLevel(ctx context.Context, level ipmi.Pri
 	return cmd.Rsp.PrivilegeLevel, nil
 }
 
+func (s *V2Session) GetBestCipherSuite(ctx context.Context) (*ipmi.GetChannelCipherSuitesRsp, error) {
+	return getBestCipherSuite(ctx, s)
+}
+
 func (s *V2Session) closeSession(ctx context.Context) error {
 	// we decrement regardless of whether this command succeeds, as to not do so
 	// would be overly pessimistic - if it fails, there's nothing we can do;

--- a/v2sessionless.go
+++ b/v2sessionless.go
@@ -307,6 +307,76 @@ func getChannelAuthenticationCapabilities(
 	return &cmd.Rsp, nil
 }
 
+func getCipherSuite(
+	ctx context.Context,
+	c Connection,
+	r *ipmi.GetChannelCipherSuitesReq,
+) (*ipmi.GetChannelCipherSuitesRsp, error) {
+	cmd := &ipmi.GetChannelCipherCmd{
+		Req: *r,
+	}
+	if err := ValidateResponse(c.SendCommand(ctx, cmd)); err != nil {
+		return nil, err
+	}
+	return &cmd.Rsp, nil
+}
+
+func getBestCipherSuite(
+	ctx context.Context,
+	c Connection,
+) (*ipmi.GetChannelCipherSuitesRsp, error) {
+	cipherSuites := []*ipmi.GetChannelCipherSuitesRsp{}
+	listIndex := 0
+
+	// define default suite to Cipher Suite 3
+	defaultSuite := &ipmi.GetChannelCipherSuitesRsp{
+		ID: ipmi.CipherSuiteID_3,
+		AuthenticationAlgorithms: []ipmi.AuthenticationAlgorithm{
+			ipmi.AuthenticationAlgorithmHMACSHA1,
+		},
+		IntegrityAlgorithms: []ipmi.IntegrityAlgorithm{
+			ipmi.IntegrityAlgorithmHMACSHA196,
+		},
+		ConfidentialityAlgorithms: []ipmi.ConfidentialityAlgorithm{
+			ipmi.ConfidentialityAlgorithmAESCBC128,
+		},
+	}
+
+	for {
+		if cs, err := getCipherSuite(ctx, c,
+			&ipmi.GetChannelCipherSuitesReq{
+				Channel:     ipmi.ChannelPresentInterface,
+				PayloadType: ipmi.PayloadTypeIPMI,
+				ListIndex:   ipmi.CipherSuiteData(listIndex),
+			}); err != nil {
+			// fall back to Cipher Suite 3
+			return defaultSuite, err
+		} else {
+			cipherSuites = append(cipherSuites, cs)
+			if cs.ListDataExhausted {
+				break
+			}
+
+			listIndex += 1
+		}
+	}
+	orderPreferred := []ipmi.CipherSuiteData{ipmi.CipherSuiteID_17, ipmi.CipherSuiteID_3}
+	for i := 0; i < len(cipherSuites); i++ {
+		for j := 0; j < len(orderPreferred); j++ {
+			if cipherSuites[i].ID == orderPreferred[j] {
+				return cipherSuites[i], nil
+			}
+		}
+	}
+
+	// fall back to Cipher Suite 3
+	return defaultSuite, fmt.Errorf("get best cipher suite failed")
+}
+
+func (s *V2Sessionless) GetBestCipherSuite(ctx context.Context) (*ipmi.GetChannelCipherSuitesRsp, error) {
+	return getBestCipherSuite(ctx, s)
+}
+
 func (s *V2Sessionless) openSession(ctx context.Context, r *ipmi.OpenSessionReq) (*ipmi.OpenSessionRsp, error) {
 	// if we were being *really* aggressive, we could store these payloads in
 	// the sessionless struct for reuse during any future session establishments


### PR DESCRIPTION
Implement the `Get Channel Cipher Suites` command and a function to get
proper Cipher Suite for authentication in new session. Currently
implementation prefer Cipher Suite 17 and fall back to Cipher Suite 3.

Reference: section 22.15, IPMI v2.0

Signed-off-by: Dong, Xiaocheng <xiaocheng.dong@intel.com>