### PR TITLE
Handle Unicode as 8 bit ASCII+LATIN1

### DIFF
--- a/pkg/ipmi/id_string.go
+++ b/pkg/ipmi/id_string.go
@@ -68,6 +68,7 @@ var (
 		// it. It might be that StringDecoderFunc(decode8BitAsciiLatin1) is
 		// sufficient.
 
+		StringEncodingUnicode:         StringDecoderFunc(decode8BitAsciiLatin1),
 		StringEncodingBCDPlus:         StringDecoderFunc(decodeBCDPlus),
 		StringEncodingPacked6BitAscii: StringDecoderFunc(decodePacked6BitAscii),
 		StringEncoding8BitAsciiLatin1: StringDecoderFunc(decode8BitAsciiLatin1),


### PR DESCRIPTION
`ASCII+LATIN1` is derived from the first 256 characters of Unicode 2.0, Unicode could be handled as 8 bit `ASCII+LATIN1`

Signed-off-by: Dong, Xiaocheng <xiaocheng.dong@intel.com>