### PR TITLE
DialV2: add support for custom timeouts

### DIFF
--- a/bmc.go
+++ b/bmc.go
@@ -41,8 +41,8 @@ func WithTimeout(t time.Duration) OptionFunc {
 // will be returned. If you know the BMC's capabilities, or need a specific
 // feature (e.g. DCMI), use the DialV*() functions instead, which expose
 // additional information and functionality.
-func Dial(_ context.Context, addr string, options ...OptionFunc) (SessionlessTransport, error) {
-	return DialV2(addr, options...)
+func Dial(_ context.Context, addr string, opts ...OptionFunc) (SessionlessTransport, error) {
+	return DialV2(addr, opts...)
 }
 
 // DialV2 establishes a new IPMI v2.0 connection with the supplied BMC. The
@@ -50,7 +50,7 @@ func Dial(_ context.Context, addr string, options ...OptionFunc) (SessionlessTra
 // Use this if you know the BMC supports IPMI v2.0 and/or require DCMI
 // functionality. Note v4 is preferred to v6 if a hostname is passed returning
 // both A and AAAA records.
-func DialV2(addr string, options ...OptionFunc) (*V2SessionlessTransport, error) {
+func DialV2(addr string, opts ...OptionFunc) (*V2SessionlessTransport, error) {
 	v2ConnectionOpenAttempts.Inc()
 	t, err := newTransport(addr)
 	if err != nil {
@@ -61,8 +61,8 @@ func DialV2(addr string, options ...OptionFunc) (*V2SessionlessTransport, error)
 	c := &Config{
 		Timeout: 1 * time.Second,
 	}
-	for _, option := range options {
-		option(c)
+	for _, opt := range opts {
+		opt(c)
 	}
 	return newV2SessionlessTransport(t, c), nil
 }

--- a/bmc.go
+++ b/bmc.go
@@ -29,9 +29,9 @@ type Config struct {
 
 type OptionFunc func(c *Config)
 
-func WithTimeout(timeout time.Duration) OptionFunc {
+func WithTimeout(t time.Duration) OptionFunc {
 	return func(c *Config) {
-		c.Timeout = timeout
+		c.Timeout = t
 	}
 }
 
@@ -58,7 +58,6 @@ func DialV2(addr string, options ...OptionFunc) (*V2SessionlessTransport, error)
 		return nil, err
 	}
 	v2ConnectionsOpen.Inc()
-
 	c := &Config{
 		Timeout: 1 * time.Second,
 	}

--- a/bmc.go
+++ b/bmc.go
@@ -39,6 +39,10 @@ func Dial(_ context.Context, addr string) (SessionlessTransport, error) {
 // functionality. Note v4 is preferred to v6 if a hostname is passed returning
 // both A and AAAA records.
 func DialV2(addr string) (*V2SessionlessTransport, error) {
+	return DialV2WithCustomTimeout(addr, 1*time.Second)
+}
+
+func DialV2WithCustomTimeout(addr string, timeout time.Duration) (*V2SessionlessTransport, error) {
 	v2ConnectionOpenAttempts.Inc()
 	t, err := newTransport(addr)
 	if err != nil {
@@ -46,13 +50,13 @@ func DialV2(addr string) (*V2SessionlessTransport, error) {
 		return nil, err
 	}
 	v2ConnectionsOpen.Inc()
-	return newV2SessionlessTransport(t), nil
+	return newV2SessionlessTransport(t, timeout), nil
 }
 
-func newV2SessionlessTransport(t transport.Transport) *V2SessionlessTransport {
+func newV2SessionlessTransport(t transport.Transport, timeout time.Duration) *V2SessionlessTransport {
 	return &V2SessionlessTransport{
 		Transport:     t,
-		V2Sessionless: newV2Sessionless(t, time.Second),
+		V2Sessionless: newV2Sessionless(t, timeout),
 	}
 }
 

--- a/bmc.go
+++ b/bmc.go
@@ -23,15 +23,15 @@ var (
 	namespace = "bmc"
 )
 
-type Config struct {
-	Timeout time.Duration
+type dialConfig struct {
+	timeout time.Duration
 }
 
-type OptionFunc func(c *Config)
+type DialConfigOption func(c *dialConfig)
 
-func WithTimeout(t time.Duration) OptionFunc {
-	return func(c *Config) {
-		c.Timeout = t
+func WithTimeout(t time.Duration) DialConfigOption {
+	return func(c *dialConfig) {
+		c.timeout = t
 	}
 }
 
@@ -41,7 +41,7 @@ func WithTimeout(t time.Duration) OptionFunc {
 // will be returned. If you know the BMC's capabilities, or need a specific
 // feature (e.g. DCMI), use the DialV*() functions instead, which expose
 // additional information and functionality.
-func Dial(_ context.Context, addr string, opts ...OptionFunc) (SessionlessTransport, error) {
+func Dial(_ context.Context, addr string, opts ...DialConfigOption) (SessionlessTransport, error) {
 	return DialV2(addr, opts...)
 }
 
@@ -50,7 +50,7 @@ func Dial(_ context.Context, addr string, opts ...OptionFunc) (SessionlessTransp
 // Use this if you know the BMC supports IPMI v2.0 and/or require DCMI
 // functionality. Note v4 is preferred to v6 if a hostname is passed returning
 // both A and AAAA records.
-func DialV2(addr string, opts ...OptionFunc) (*V2SessionlessTransport, error) {
+func DialV2(addr string, opts ...DialConfigOption) (*V2SessionlessTransport, error) {
 	v2ConnectionOpenAttempts.Inc()
 	t, err := newTransport(addr)
 	if err != nil {
@@ -58,8 +58,8 @@ func DialV2(addr string, opts ...OptionFunc) (*V2SessionlessTransport, error) {
 		return nil, err
 	}
 	v2ConnectionsOpen.Inc()
-	c := &Config{
-		Timeout: 1 * time.Second,
+	c := &dialConfig{
+		timeout: 1 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -67,10 +67,10 @@ func DialV2(addr string, opts ...OptionFunc) (*V2SessionlessTransport, error) {
 	return newV2SessionlessTransport(t, c), nil
 }
 
-func newV2SessionlessTransport(t transport.Transport, c *Config) *V2SessionlessTransport {
+func newV2SessionlessTransport(t transport.Transport, c *dialConfig) *V2SessionlessTransport {
 	return &V2SessionlessTransport{
 		Transport:     t,
-		V2Sessionless: newV2Sessionless(t, c.Timeout),
+		V2Sessionless: newV2Sessionless(t, c.timeout),
 	}
 }
 


### PR DESCRIPTION
Add support for custom transport timeouts. Discussed [here](https://github.com/gebn/bmc/issues/62#issuecomment-1878479915).