### PR TITLE
SDRRepository: implement two-part reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,8 @@ Be sure to add response operations to the `operationLayerTypes` map in this file
 If the request or response payload has any enum-style fields, e.g. `ChassisControl`, create a new type with constants for its possible values, then implement `fmt.Stringer` to make it print nicely.
 It is recommended not to embed any fields implementing `fmt.Stringer` in a layer, as this means it cannot be printed by `gopacket` (there is an issue [here](https://github.com/google/gopacket/issues/683)).
 
-Session-less commands should be added to the `SessionlessCommands` interface, and the response, if any, to the `sessionlessRspLayers` struct, then the appropriate decoders in `v(1|2)sessionless.go`.
-Commands that must be sent inside a session should be added to the `SessionCommands` interface, and the response, if any, to the `sessionRspLayers` struct, then the appropriate decoders in `v(1|2)session.go`.
+Session-less commands should be added to the `SessionlessCommands` interface, then the appropriate decoders in `v(1|2)sessionless.go`.
+Commands that must be sent inside a session should be added to the `SessionCommands` interface, then the appropriate decoders in `v(1|2)session.go`.
 Writing appropriate implementations for IPMI v1.5 and v2.0 in `v1session(less).go` and `v2session(less).go` respectively makes the command easy for users to execute.
 
 ### Examples

--- a/pkg/ipmi/completion_code.go
+++ b/pkg/ipmi/completion_code.go
@@ -26,6 +26,11 @@ const (
 	CompletionCodeUnrecognisedCommand CompletionCode = 0xc1
 	CompletionCodeTimeout             CompletionCode = 0xc3
 
+	// CompletionCodeReservationCanceledOrInvalid means that either the
+	// requester's reservation has been canceled or the request's reservation
+	// ID is invalid.
+	CompletionCodeReservationCanceledOrInvalid CompletionCode = 0xc5
+
 	// CompletionCodeRequestTruncated means the request ended prematurely. Did
 	// you forget to add the final request data layer?
 	CompletionCodeRequestTruncated CompletionCode = 0xc6

--- a/pkg/ipmi/get_device_id_test.go
+++ b/pkg/ipmi/get_device_id_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
-func TestGetDecideIDRspDecodeFromBytes(t *testing.T) {
+func TestGetDeviceIDRspDecodeFromBytes(t *testing.T) {
 	tests := []struct {
 		in   []byte
 		want *GetDeviceIDRsp

--- a/pkg/ipmi/layer_types.go
+++ b/pkg/ipmi/layer_types.go
@@ -257,4 +257,13 @@ var (
 			}),
 		},
 	)
+	LayerTypeReserveSDRRepositoryRsp = gopacket.RegisterLayerType(
+		1031,
+		gopacket.LayerTypeMetadata{
+			Name: "Reserve SDR Repository Response",
+			Decoder: layerexts.BuildDecoder(func() layerexts.LayerDecodingLayer {
+				return &ReserveSDRRepositoryRsp{}
+			}),
+		},
+	)
 )

--- a/pkg/ipmi/operation.go
+++ b/pkg/ipmi/operation.go
@@ -86,6 +86,14 @@ var (
 		Function: NetworkFunctionStorageRsp,
 		Command:  0x20,
 	}
+	OperationReserveSDRRepositoryReq = Operation{
+		Function: NetworkFunctionStorageReq,
+		Command:  0x22,
+	}
+	OperationReserveSDRRepositoryRsp = Operation{
+		Function: NetworkFunctionStorageRsp,
+		Command:  0x22,
+	}
 	OperationGetSDRReq = Operation{
 		Function: NetworkFunctionStorageReq,
 		Command:  0x23,
@@ -135,6 +143,7 @@ var (
 		OperationGetChannelAuthenticationCapabilitiesRsp: LayerTypeGetChannelAuthenticationCapabilitiesRsp,
 		OperationSetSessionPrivilegeLevelRsp:             LayerTypeSetSessionPrivilegeLevelRsp,
 		OperationGetSDRRepositoryInfoRsp:                 LayerTypeGetSDRRepositoryInfoRsp,
+		OperationReserveSDRRepositoryRsp:                 LayerTypeReserveSDRRepositoryRsp,
 		OperationGetSDRRsp:                               LayerTypeGetSDRRsp,
 		OperationGetSensorReadingRsp:                     LayerTypeGetSensorReadingRsp,
 		OperationGetSessionInfoRsp:                       LayerTypeGetSessionInfoRsp,

--- a/pkg/ipmi/reserve_sdr_repository.go
+++ b/pkg/ipmi/reserve_sdr_repository.go
@@ -29,9 +29,9 @@ func (*ReserveSDRRepositoryRsp) NextLayerType() gopacket.LayerType {
 }
 
 func (r *ReserveSDRRepositoryRsp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	if len(data) != 2 {
+	if len(data) < 2 {
 		df.SetTruncated()
-		return fmt.Errorf("response must be 2 bytes, got %v", len(data))
+		return fmt.Errorf("response must be at least 2 bytes, got %v", len(data))
 	}
 
 	r.BaseLayer.Contents = data[:2]

--- a/pkg/ipmi/reserve_sdr_repository.go
+++ b/pkg/ipmi/reserve_sdr_repository.go
@@ -1,0 +1,66 @@
+package ipmi
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// ReserveSDRRepositoryRsp represents the response to a Reserve SDR Repository
+// command, specified in 33.11 of IPMI v2.0.
+type ReserveSDRRepositoryRsp struct {
+	layers.BaseLayer
+
+	ReservationID ReservationID
+}
+
+func (*ReserveSDRRepositoryRsp) LayerType() gopacket.LayerType {
+	return LayerTypeReserveSDRRepositoryRsp
+}
+
+func (r *ReserveSDRRepositoryRsp) CanDecode() gopacket.LayerClass {
+	return r.LayerType()
+}
+
+func (*ReserveSDRRepositoryRsp) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypePayload
+}
+
+func (r *ReserveSDRRepositoryRsp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) != 2 {
+		df.SetTruncated()
+		return fmt.Errorf("response must be 2 bytes, got %v", len(data))
+	}
+
+	r.BaseLayer.Contents = data[:2]
+	r.ReservationID = ReservationID(binary.LittleEndian.Uint16(data[0:2]))
+	return nil
+}
+
+type ReserveSDRRepositoryCmd struct {
+	Rsp ReserveSDRRepositoryRsp
+}
+
+// Name returns "Reserve SDR Repository".
+func (*ReserveSDRRepositoryCmd) Name() string {
+	return "Reserve SDR Repository"
+}
+
+// Operation returns &OperationReserveSDRRepositoryReq.
+func (*ReserveSDRRepositoryCmd) Operation() *Operation {
+	return &OperationReserveSDRRepositoryReq
+}
+
+func (c *ReserveSDRRepositoryCmd) RemoteLUN() LUN {
+	return LUNBMC
+}
+
+func (c *ReserveSDRRepositoryCmd) Request() gopacket.SerializableLayer {
+	return nil
+}
+
+func (c *ReserveSDRRepositoryCmd) Response() gopacket.DecodingLayer {
+	return &c.Rsp
+}

--- a/pkg/ipmi/reserve_sdr_repository_test.go
+++ b/pkg/ipmi/reserve_sdr_repository_test.go
@@ -1,0 +1,32 @@
+package ipmi
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"testing"
+)
+
+func TestReserveSDRRepositoryRspDecodeFomBytes(t *testing.T) {
+	tests := []struct {
+		in   []byte
+		want *ReserveSDRRepositoryRsp
+	}{
+		{
+			in: []byte{0x20, 0x58},
+			want: &ReserveSDRRepositoryRsp{
+				BaseLayer:     layers.BaseLayer{Contents: []byte{0x20, 0x58}},
+				ReservationID: 22560,
+			},
+		},
+	}
+	for _, test := range tests {
+		rsp := &ReserveSDRRepositoryRsp{}
+		if err := rsp.DecodeFromBytes(test.in, gopacket.NilDecodeFeedback); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(test.want, rsp); diff != "" {
+			t.Errorf("decode %v = %v, want %v: %v", test.in, rsp, test.want, diff)
+		}
+	}
+}

--- a/pkg/ipmi/sdr.go
+++ b/pkg/ipmi/sdr.go
@@ -34,17 +34,17 @@ type SDR struct {
 	// to sensors.
 	Type RecordType
 
-	// There is a 1-byte length field containing the number of remaining bytes
-	// in the payload (i.e. after the header), so the max SDR size on the wire
-	// is 260 bytes. In practice, OEM records notwithstanding, it is unlikely to
-	// be >60.
+	// Length is the number of remaining bytes in the payload (i.e. after the header).
 	//
+	// This means the max SDR size on the wire is 260 bytes. In practice, OEM
+	// records notwithstanding, it is unlikely to be >60.
 	// If it weren't for this field, the limit for the whole SDR including
 	// header could theoretically be 255 + the max supported payload size (the
 	// SDR Repo Device commands provide no way to address subsequent sections
 	// for reading).
-
-	// payload contains the record key and body
+	//
+	// payload contains the record key and body.
+	Length uint8
 }
 
 func (*SDR) LayerType() gopacket.LayerType {
@@ -68,6 +68,7 @@ func (s *SDR) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	s.ID = RecordID(binary.LittleEndian.Uint16(data[0:2]))
 	s.Version = bcd.Decode(data[2]&0xf)*10 + bcd.Decode(data[2]>>4)
 	s.Type = RecordType(data[3])
+	s.Length = data[4]
 
 	s.BaseLayer.Contents = data[:5]
 	s.BaseLayer.Payload = data[5:]

--- a/pkg/ipmi/sdr.go
+++ b/pkg/ipmi/sdr.go
@@ -38,13 +38,14 @@ type SDR struct {
 	//
 	// This means the max SDR size on the wire is 260 bytes. In practice, OEM
 	// records notwithstanding, it is unlikely to be >60.
+	//
 	// If it weren't for this field, the limit for the whole SDR including
 	// header could theoretically be 255 + the max supported payload size (the
 	// SDR Repo Device commands provide no way to address subsequent sections
 	// for reading).
-	//
-	// payload contains the record key and body.
 	Length uint8
+
+	// payload contains the record key and body.
 }
 
 func (*SDR) LayerType() gopacket.LayerType {
@@ -68,7 +69,7 @@ func (s *SDR) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	s.ID = RecordID(binary.LittleEndian.Uint16(data[0:2]))
 	s.Version = bcd.Decode(data[2]&0xf)*10 + bcd.Decode(data[2]>>4)
 	s.Type = RecordType(data[3])
-	s.Length = data[4]
+	s.Length = uint8(data[4])
 
 	s.BaseLayer.Contents = data[:5]
 	s.BaseLayer.Payload = data[5:]

--- a/pkg/ipmi/sdr_test.go
+++ b/pkg/ipmi/sdr_test.go
@@ -38,6 +38,7 @@ func TestSDRDecodeFromBytes(t *testing.T) {
 				ID:      61455,
 				Version: 99,
 				Type:    RecordTypeFullSensor,
+				Length:  22,
 			},
 		},
 		{
@@ -61,6 +62,7 @@ func TestSDRDecodeFromBytes(t *testing.T) {
 				ID:      4080,
 				Version: 15,
 				Type:    RecordTypeCompactSensor,
+				Length:  32,
 			},
 		},
 	}

--- a/sdr_repository.go
+++ b/sdr_repository.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	sdrHeaderLength = uint8(5)
-	sdrMaxLength    = uint8(64)
+	sdrHeaderLength = 5
+	sdrMaxLength    = 64
 )
 
 var (

--- a/sdr_repository.go
+++ b/sdr_repository.go
@@ -109,7 +109,7 @@ func walkSDRs(ctx context.Context, s Session) (SDRRepository, error) {
 					getSDRCmd.Req.RecordID, header.Length)
 			}
 
-			getSDRCmd.Req.Offset = getSDRCmd.Req.Length
+			getSDRCmd.Req.Offset = numBytesSDRHeader
 			getSDRCmd.Req.Length = header.Length
 			if err := ValidateResponse(s.SendCommand(ctx, getSDRCmd)); err != nil {
 				return nil, err

--- a/sdr_repository.go
+++ b/sdr_repository.go
@@ -96,7 +96,7 @@ func walkSDRs(ctx context.Context, s Session) (SDRRepository, error) {
 				getSDRCmd.Req.RecordID)
 		}
 		headerLayer := headerPacket.Layer(ipmi.LayerTypeSDR)
-		if headerLayer != nil {
+		if headerLayer == nil {
 			return nil, fmt.Errorf("invalid SDR for record ID %d: missing SDR layer",
 				getSDRCmd.Req.RecordID)
 		}
@@ -121,7 +121,7 @@ func walkSDRs(ctx context.Context, s Session) (SDRRepository, error) {
 					getSDRCmd.Req.RecordID)
 			}
 			fsrLayer := fsrPacket.Layer(ipmi.LayerTypeFullSensorRecord)
-			if fsrLayer != nil {
+			if fsrLayer == nil {
 				return nil, fmt.Errorf("invalid SDR for record ID %d: missing FSR layer",
 					getSDRCmd.Req.RecordID)
 			}

--- a/session_commands.go
+++ b/session_commands.go
@@ -36,6 +36,12 @@ type SessionCommands interface {
 	// respectively.
 	GetSDRRepositoryInfo(context.Context) (*ipmi.GetSDRRepositoryInfoRsp, error)
 
+	// ReserveSDRRepository sets the requester as the present "owner" of the
+	// repository. The returned reservation ID must be included in requests that
+	// either delete or partially read/write an SDR.
+	// This is specified in 33.11 of IPMI v2.0.
+	ReserveSDRRepository(context.Context) (*ipmi.ReserveSDRRepositoryRsp, error)
+
 	// GetSensorReading retrieves the current value of a sensor, identified by
 	// its number. It is specified in 29.14 and 35.14 of IPMI v1.5 and 2.0
 	// respectively. Note, the raw value is in one of three formats, and is

--- a/v2session.go
+++ b/v2session.go
@@ -271,6 +271,14 @@ func (s *V2Session) GetSDRRepositoryInfo(ctx context.Context) (*ipmi.GetSDRRepos
 	return &cmd.Rsp, nil
 }
 
+func (s *V2Session) ReserveSDRRepository(ctx context.Context) (*ipmi.ReserveSDRRepositoryRsp, error) {
+	cmd := &ipmi.ReserveSDRRepositoryCmd{}
+	if err := ValidateResponse(s.SendCommand(ctx, cmd)); err != nil {
+		return nil, err
+	}
+	return &cmd.Rsp, nil
+}
+
 func (s *V2Session) GetSensorReading(ctx context.Context, sensor uint8) (*ipmi.GetSensorReadingRsp, error) {
 	cmd := &ipmi.GetSensorReadingCmd{
 		Req: ipmi.GetSensorReadingReq{


### PR DESCRIPTION
Update how SDRRepository walks the repo so that the SDR key fields and body are only requested if the SDR type is `FullSensorRecord`. This increases the number of commands needed to read an SDR repo, but it's necessary to work around BMCs that occasionally return a malformed packet when the request's `Length` is `0xff`.

Discussed [here](https://github.com/gebn/bmc/issues/62#issuecomment-1902845224).